### PR TITLE
chore: exclude markdown files from prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ build
 .next
 pnpm-lock.yaml
 *.tsbuildinfo
+*.md

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "*.{json,md,yml,yaml}": [
+    "*.{json,yml,yaml}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
Skip all markdown files (*.md) from automatic formatting to prevent conflicts with auto-generated files like CHANGELOG.md.